### PR TITLE
discover: fix discover not updating on end, prevent double calls

### DIFF
--- a/src/renderer/src/components/beatmaps.svelte
+++ b/src/renderer/src/components/beatmaps.svelte
@@ -28,7 +28,7 @@
     export let set = false;
     export let show_control = true;
     export let remove_callback = () => {};
-    export let on_end = () => {};
+    export let on_update = null;
 
     const list = list_manager || get_beatmap_list(tab_id);
     const { beatmaps, selected } = list;
@@ -162,7 +162,7 @@
         {tab_id}
         {direction}
         {columns}
-        {on_end}
+        {on_update}
         let:index
     >
         {@const hash = $beatmaps[index]}

--- a/src/renderer/src/components/tabs/discover.svelte
+++ b/src/renderer/src/components/tabs/discover.svelte
@@ -14,11 +14,6 @@
 
     $: query = discover.query;
     $: data = discover.data;
-    $: should_update = discover.should_update;
-
-    $: if ($should_update) {
-        discover.search();
-    }
 </script>
 
 <div class="content tab-content">
@@ -61,6 +56,20 @@
         </div>
 
         <!-- render beatmap list -->
-        <Beatmaps show_context={false} set={true} columns={2} list_manager={discover} />
+        <Beatmaps
+            show_context={false}
+            set={true}
+            columns={2}
+            list_manager={discover}
+            on_update={(i) => {
+                // update list on 10 items to the end
+                if (discover.can_load_more() && discover.get_list_length() - i <= 10) {
+                    console.log(`[discover] loading more at item ${i}/${discover.get_list_length()}`);
+                    discover.search();
+                } else {
+                    console.log("discover.can_load_more() -> false:", discover.can_load_more(), discover.get_list_length() - i <= 10);
+                }
+            }}
+        />
     </div>
 </div>

--- a/src/renderer/src/components/tabs/discover.svelte
+++ b/src/renderer/src/components/tabs/discover.svelte
@@ -64,10 +64,7 @@
             on_update={(i) => {
                 // update list on 10 items to the end
                 if (discover.can_load_more() && discover.get_list_length() - i <= 10) {
-                    console.log(`[discover] loading more at item ${i}/${discover.get_list_length()}`);
                     discover.search();
-                } else {
-                    console.log("discover.can_load_more() -> false:", discover.can_load_more(), discover.get_list_length() - i <= 10);
                 }
             }}
         />

--- a/src/renderer/src/lib/store/beatmaps.js
+++ b/src/renderer/src/lib/store/beatmaps.js
@@ -60,6 +60,10 @@ export class BeatmapListBase {
         return get(this.items);
     }
 
+    get_list_length() {
+        return get(this.items).length;
+    }
+
     set_items(items, key, ignore_context = false) {
         this.items.set(items);
 

--- a/src/renderer/src/lib/store/discover.js
+++ b/src/renderer/src/lib/store/discover.js
@@ -189,7 +189,7 @@ class DiscoverManager extends BeatmapListBase {
                 return;
             }
 
-            const data = result.json();
+            const data = await result.json();
 
             // check if we have any beatmaps left to search
             if (!data.beatmapsets || data.beatmapsets.length == 0) {

--- a/src/renderer/src/lib/store/discover.js
+++ b/src/renderer/src/lib/store/discover.js
@@ -145,7 +145,6 @@ class DiscoverManager extends BeatmapListBase {
     search = debounce(async () => {
         // only one at time baby
         if (get(this.is_loading)) {
-            console.log("[discover] already loading, skipping...");
             return;
         }
 
@@ -192,10 +191,9 @@ class DiscoverManager extends BeatmapListBase {
 
             const data = result.json();
 
-            // Verifica se não há mais resultados
+            // check if we have any beatmaps left to search
             if (!data.beatmapsets || data.beatmapsets.length == 0) {
                 this.has_reached_end.set(true);
-                console.log("[discover] no more results available");
                 return;
             }
 
@@ -213,7 +211,7 @@ class DiscoverManager extends BeatmapListBase {
 
             const current_cursor = get(this.cursor);
 
-            // Atualiza a lista de beatmaps
+            // update beatmap list
             if (current_cursor == "") {
                 this.beatmaps.set([...updated_beatmapsets]);
             } else {

--- a/src/renderer/src/lib/store/discover.js
+++ b/src/renderer/src/lib/store/discover.js
@@ -1,7 +1,7 @@
 import { get, writable } from "svelte/store";
 import { access_token } from "./config";
 import { show_notification } from "./notifications";
-import { BeatmapListBase, osu_beatmaps } from "./beatmaps";
+import { BeatmapListBase } from "./beatmaps";
 import { debounce } from "../utils/utils";
 
 // l
@@ -67,6 +67,8 @@ class DiscoverManager extends BeatmapListBase {
         this.last_query = writable("");
         this.data = writable(DEFAULT_DATA_VALUES);
         this.should_update = writable(false);
+        this.is_loading = writable(false);
+        this.has_reached_end = writable(false);
 
         // track last search state to detect changes
         this.last_search_state = "";
@@ -141,6 +143,12 @@ class DiscoverManager extends BeatmapListBase {
     }
 
     search = debounce(async () => {
+        // only one at time baby
+        if (get(this.is_loading)) {
+            console.log("[discover] already loading, skipping...");
+            return;
+        }
+
         const token = get(access_token);
 
         if (token == "") {
@@ -148,20 +156,99 @@ class DiscoverManager extends BeatmapListBase {
             return;
         }
 
+        // dont make more request if we reached the end
+        if (get(this.has_reached_end)) {
+            console.log("[discover] reached end of results");
+            return;
+        }
+
+        this.is_loading.set(true);
+
         const current_state = this.get_current_search_state();
 
         // reset cursor/beatmaps if search parameters changed
         if (this.last_search_state != current_state) {
             this.cursor.set("");
             this.beatmaps.set([]);
+            this.has_reached_end.set(false);
             this.last_search_state = current_state;
         }
 
-        const normalized_data = [];
+        try {
+            const normalized_data = this.normalize_filter_data(get(this.data));
+            const baked_url = this.bake_url(normalized_data);
 
-        for (const [key, values] of Object.entries(get(this.data))) {
-            // for some reason the osu! api use a single char for filter params...
+            const result = await window.fetch({
+                url: baked_url,
+                headers: {
+                    Authorization: "Bearer " + token
+                }
+            });
+
+            if (result.status != 200) {
+                console.log("[discover] failed to fetch beatmaps", result);
+                return;
+            }
+
+            const data = result.json();
+
+            // Verifica se não há mais resultados
+            if (!data.beatmapsets || data.beatmapsets.length == 0) {
+                this.has_reached_end.set(true);
+                console.log("[discover] no more results available");
+                return;
+            }
+
+            // append download, local
+            const updated_beatmapsets = await Promise.all(
+                data.beatmapsets.map(async (set) => {
+                    const local_beatmap = await this.get_from_local_by_id(set.id);
+                    if (local_beatmap) {
+                        set.downloaded = local_beatmap.downloaded;
+                        set.local = local_beatmap.local;
+                    }
+                    return set;
+                })
+            );
+
+            const current_cursor = get(this.cursor);
+
+            // Atualiza a lista de beatmaps
+            if (current_cursor == "") {
+                this.beatmaps.set([...updated_beatmapsets]);
+            } else {
+                this.beatmaps.update((sets) => [...sets, ...updated_beatmapsets]);
+            }
+
+            // update cursor
+            const new_cursor = data.cursor_string || "";
+            this.cursor.set(new_cursor);
+
+            // that means we reached the end ;-;
+            if (new_cursor == "") {
+                this.has_reached_end.set(true);
+            }
+
+            this.last_query.set(get(this.query));
+        } catch (error) {
+            console.error("[discover] search error:", error);
+            show_notification({ type: "error", text: "failed to search beatmaps" });
+        } finally {
+            this.is_loading.set(false);
+        }
+    }, 500);
+
+    normalize_filter_data(data) {
+        const normalized_data = {};
+
+        for (const [key, values] of Object.entries(data)) {
+            // for some reason the osu! api use a single char for filter params..
             const filter_data = filter_map.get(key);
+
+            if (!filter_data) {
+                continue;
+            }
+
             const new_key = filter_data.code;
 
             // return the expected filter value (ex: japanese -> 13)
@@ -172,57 +259,22 @@ class DiscoverManager extends BeatmapListBase {
                 } else {
                     normalized_data[new_key] = filter_data.data[values];
                 }
-            } else {
-                for (const value of values) {
-                    // in this case, the value will be the same
-                    if (Array.isArray(filter_data.data)) {
-                        normalized_data[new_key] = value;
-                    } else {
-                        normalized_data[new_key] = filter_data.data[value];
+            } else if (Array.isArray(values) && values.length > 0) {
+                // in this case, the value will be the same
+                if (Array.isArray(filter_data.data)) {
+                    normalized_data[new_key] = values;
+                } else {
+                    const mapped_values = values.map((value) => filter_data.data[value]).filter((val) => val != undefined);
+
+                    if (mapped_values.length > 0) {
+                        normalized_data[new_key] = mapped_values;
                     }
                 }
             }
         }
 
-        const baked_url = this.bake_url(normalized_data);
-
-        const result = await window.fetch({
-            url: baked_url,
-            headers: {
-                Authorization: "Bearer " + token
-            }
-        });
-
-        if (result.status != 200) {
-            console.log("[discover] failed to fetch beatmaps", result);
-            return;
-        }
-
-        const data = result.json();
-
-        // only append if we are paginating, otherwise replace
-        const current_cursor = get(this.cursor);
-
-        // append download, local (so we know what maps we have)
-        const updated_beatmapsets = data.beatmapsets.map(async (set) => {
-            const local_beatmap = await this.get_from_local_by_id(set.id);
-            if (local_beatmap) {
-                set.downloaded = local_beatmap.downloaded;
-                set.local = local_beatmap.local;
-            }
-            return set;
-        });
-
-        if (current_cursor == "") {
-            this.beatmaps.set([...updated_beatmapsets]);
-        } else {
-            this.beatmaps.update((sets) => [...sets, ...updated_beatmapsets]);
-        }
-
-        this.cursor.set(data.cursor_string || "");
-        this.last_query.set(get(this.query));
-        this.should_update.set(false);
-    }, 250);
+        return normalized_data;
+    }
 
     update(type, value) {
         if (!filter_map.has(type)) {
@@ -254,7 +306,7 @@ class DiscoverManager extends BeatmapListBase {
         // force immediate reset and search trigger
         this.cursor.set("");
         this.beatmaps.set([]);
-        this.should_update.set(true);
+        this.has_reached_end.set(false);
 
         // trigger search immediately after filter change
         this.search();
@@ -278,7 +330,12 @@ class DiscoverManager extends BeatmapListBase {
     update_query(value) {
         if (get(this.query) == value) return;
         this.query.set(value);
+        this.has_reached_end.set(false);
         this.search();
+    }
+
+    can_load_more() {
+        return !get(this.is_loading) && !get(this.has_reached_end);
     }
 }
 


### PR DESCRIPTION
- [x] virtual list: replace on_end with on_update
- [x] discover: use on_update to check if we're close to the end
- [x] discover: get new beatmaps on end
- [x] discover: detect when we reached the list limit (no beatmaps left)

## Summary by Sourcery

Refactor the discover pagination flow to use a unified on_update callback instead of on_end, add loading and end-of-list guards to prevent duplicate or unnecessary fetches, and simplify filter normalization logic.

Bug Fixes:
- Prevent duplicate fetch calls when already loading or after reaching the end of results
- Ensure discover search triggers correctly when nearing the end of the list

Enhancements:
- Replace on_end with a debounced on_update callback in virtual list and beatmaps components
- Add is_loading and has_reached_end flags in DiscoverManager to gate concurrent and end-of-list requests
- Simplify normalize_filter_data and consolidate filter normalization logic
- Introduce can_load_more and get_list_length helpers to facilitate load checks