### PR TITLE
beatmaps list: send list info (count, etc...) instead of hashes (loads faster)

### DIFF
--- a/src/main/beatmaps/downloader.js
+++ b/src/main/beatmaps/downloader.js
@@ -657,7 +657,7 @@ const export_beatmaps = async (collection_names) => {
                     continue;
                 }
 
-                if (!Array.isArray(collection.maps) || collection.maps.length == 0) {
+                if (collection.count == 0) {
                     continue;
                 }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -5,13 +5,13 @@ import { initialize_config, config, update_config_database } from "./database/co
 import { initialize_indexer } from "./database/indexer";
 import { initialize_mirrors } from "./database/mirrors";
 import {
+    load_beatmaps_from_database,
     add_beatmap,
-    filter_beatmaps,
     get_beatmap_by_md5,
     get_beatmap_by_set_id,
     get_beatmap_data,
-    get_beatmaps_from_database,
-    get_missing_beatmaps
+    get_missing_beatmaps,
+    update_beatmap_list
 } from "./beatmaps/beatmaps";
 import { get_and_update_collections, update_collections, get_collection_data, export_collection } from "./beatmaps/collections";
 import { FetchManager } from "./fetch";
@@ -110,15 +110,15 @@ async function createWindow() {
     });
 
     // osu related stuff
+    ipcMain.handle("load-beatmaps", (_, force) => load_beatmaps_from_database(force));
     ipcMain.handle("add-beatmap", (_, hash, beatmap) => add_beatmap(hash, beatmap));
-    ipcMain.handle("get-beatmaps", (_, force) => get_beatmaps_from_database(force));
     ipcMain.handle("get-collections", (_, force) => get_and_update_collections(force));
     ipcMain.handle("get-collection-data", (_, location, type) => get_collection_data(location, type));
     ipcMain.handle("export-collection", (_, collection, type) => export_collection(collection, type));
-    ipcMain.handle("filter-beatmaps", (_, hashes, query, extra) => filter_beatmaps(hashes, query, extra));
-    ipcMain.handle("get-beatmap", (_, data, is_unique_id) => get_beatmap_data(data, "", is_unique_id));
+    ipcMain.handle("get-beatmap", (_, options) => get_beatmap_data(options));
     ipcMain.handle("get-beatmap-by-id", (_, id) => get_beatmap_by_set_id(id));
     ipcMain.handle("get-beatmap-by-md5", (_, md5) => get_beatmap_by_md5(md5));
+    ipcMain.handle("update-beatmap-list", (_, options) => update_beatmap_list(options));
     ipcMain.handle("missing-beatmaps", (_, data) => get_missing_beatmaps(data));
     ipcMain.handle("update-collections", (_, data) => update_collections(data));
     ipcMain.handle("export-beatmaps", (_, beatmaps) => downloader.export_beatmaps(beatmaps));

--- a/src/main/reader/reader.js
+++ b/src/main/reader/reader.js
@@ -440,7 +440,8 @@ export class Reader extends BinaryReader {
                     data.collections.set(collection.Name, {
                         uuid: collection.ID.toString(),
                         name: collection.Name,
-                        maps: Array.from(collection.BeatmapMD5Hashes)
+                        maps: Array.from(collection.BeatmapMD5Hashes),
+                        deleted: []
                     });
                 }
 
@@ -477,7 +478,8 @@ export class Reader extends BinaryReader {
 
             collections.set(name, {
                 name: name,
-                maps: md5
+                maps: md5,
+                deleted: []
             });
         }
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -8,8 +8,9 @@ contextBridge.exposeInMainWorld("config", {
 });
 
 contextBridge.exposeInMainWorld("osu", {
+    load_beatmaps: (force) => ipcRenderer.invoke("load-beatmaps", force),
     add_beatmap: (md5, beatmap) => ipcRenderer.invoke("add-beatmap", md5, beatmap),
-    get_beatmaps: (force) => ipcRenderer.invoke("get-beatmaps", force),
+    get_beatmaps: (options) => ipcRenderer.invoke("get-beatmaps", options),
     get_beatmap: (md5, query) => ipcRenderer.invoke("get-beatmap", md5, query),
     get_beatmap_by_id: (id) => ipcRenderer.invoke("get-beatmap-by-id", id),
     get_beatmap_by_md5: (md5) => ipcRenderer.invoke("get-beatmap-by-md5", md5),
@@ -17,7 +18,7 @@ contextBridge.exposeInMainWorld("osu", {
     export_collection: (type, beatmtaps) => ipcRenderer.invoke("export-collection", type, beatmtaps),
     get_collection_data: (location, type) => ipcRenderer.invoke("get-collection-data", location, type),
     get_collections: (force) => ipcRenderer.invoke("get-collections", force),
-    filter_beatmaps: (...args) => ipcRenderer.invoke("filter-beatmaps", ...args),
+    update_beatmap_list: (options) => ipcRenderer.invoke("update-beatmap-list", options),
     update_collections: (data) => ipcRenderer.invoke("update-collections", data),
     export_beatmaps: (beatmaps) => ipcRenderer.invoke("export-beatmaps", beatmaps),
     export_beatmap: (beatmap) => ipcRenderer.invoke("export-beatmap", beatmap)

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -19,6 +19,7 @@
     import Header from "./components/header.svelte";
     import Notifications from "./components/utils/notifications.svelte";
     import ExportProgress from "./components/utils/export-progress.svelte";
+    import { downloader } from "./lib/store/downloader";
 
     $: initialized = false;
     $: indexing_status = $indexing_data?.status ?? "doing something";
@@ -33,11 +34,14 @@
 
     onMount(async () => {
         try {
-            // first lets check if we're on dev_mode
+            // update dev_mode var
             const dev_mode_result = await window.extra.is_dev_mode();
             is_dev_mode.set(dev_mode_result);
 
-            // then lets get beatmaps from database
+            // initialize downloader
+            await downloader.initialize();
+
+            // load beatmaps from database
             await get_osu_data(false);
             initialized = true;
         } catch (err) {

--- a/src/renderer/src/components/beatmaps.svelte
+++ b/src/renderer/src/components/beatmaps.svelte
@@ -28,7 +28,7 @@
     export let set = false;
     export let show_control = true;
     export let remove_callback = () => {};
-    export let on_end = () => {};
+    export let on_update = null;
 
     const list = list_manager || get_beatmap_list(tab_id);
     const { beatmaps, selected } = list;
@@ -162,7 +162,7 @@
         {tab_id}
         {direction}
         {columns}
-        {on_end}
+        {on_update}
         let:index
     >
         {@const hash = $beatmaps[index]}

--- a/src/renderer/src/components/beatmaps.svelte
+++ b/src/renderer/src/components/beatmaps.svelte
@@ -165,10 +165,14 @@
         {on_update}
         let:index
     >
-        {@const hash = $beatmaps[index]}
-        {#await get_beatmap_data(hash) then beatmap}
+        {@const data = $beatmaps[index]}
+        {#await get_beatmap_data({ ...data, id: list.list_id }) then beatmap}
+            <!-- update list if our old data is pending -->
+            {#if data.pending}
+                {list.update_beatmap(data.index, beatmap)}
+            {/if}
             {#if show_context}
-                <ContextMenu onclick={(event) => handle_context_menu(event, beatmap)} options={get_context_options(beatmap, hash)} at="point">
+                <ContextMenu onclick={(event) => handle_context_menu(event, beatmap)} options={get_context_options(beatmap, beatmap.md5)} at="point">
                     <BeatmapCard
                         {beatmap}
                         {show_bpm}

--- a/src/renderer/src/components/tabs/browse.svelte
+++ b/src/renderer/src/components/tabs/browse.svelte
@@ -18,7 +18,13 @@
 
     const update_beatmaps = async () => {
         const beatmaps = await list.get_beatmaps(ALL_BEATMAPS_KEY, { unique: false });
-        if (beatmaps) list.set_beatmaps(beatmaps, { name: ALL_BEATMAPS_KEY }, false);
+
+        // update list id
+        list.update_list_id(ALL_BEATMAPS_KEY);
+
+        if (beatmaps) {
+            list.set_beatmaps(beatmaps.count, { name: ALL_BEATMAPS_KEY }, false);
+        }
     };
 
     const update_sr = async (data) => {

--- a/src/renderer/src/components/tabs/discover.svelte
+++ b/src/renderer/src/components/tabs/discover.svelte
@@ -14,11 +14,6 @@
 
     $: query = discover.query;
     $: data = discover.data;
-    $: should_update = discover.should_update;
-
-    $: if ($should_update) {
-        discover.search();
-    }
 </script>
 
 <div class="content tab-content">
@@ -61,6 +56,20 @@
         </div>
 
         <!-- render beatmap list -->
-        <Beatmaps show_context={false} set={true} columns={2} list_manager={discover} />
+        <Beatmaps
+            show_context={false}
+            set={true}
+            columns={2}
+            list_manager={discover}
+            on_update={(i) => {
+                // update list on 10 items to the end
+                if (discover.can_load_more() && discover.get_list_length() - i <= 10) {
+                    console.log(`[discover] loading more at item ${i}/${discover.get_list_length()}`);
+                    discover.search();
+                } else {
+                    console.log("discover.can_load_more() -> false:", discover.can_load_more(), discover.get_list_length() - i <= 10);
+                }
+            }}
+        />
     </div>
 </div>

--- a/src/renderer/src/components/tabs/discover.svelte
+++ b/src/renderer/src/components/tabs/discover.svelte
@@ -64,10 +64,7 @@
             on_update={(i) => {
                 // update list on 10 items to the end
                 if (discover.can_load_more() && discover.get_list_length() - i <= 10) {
-                    console.log(`[discover] loading more at item ${i}/${discover.get_list_length()}`);
                     discover.search();
-                } else {
-                    console.log("discover.can_load_more() -> false:", discover.can_load_more(), discover.get_list_length() - i <= 10);
                 }
             }}
         />

--- a/src/renderer/src/components/tabs/radio.svelte
+++ b/src/renderer/src/components/tabs/radio.svelte
@@ -7,6 +7,7 @@
     import { get_beatmap_list } from "../../lib/store/beatmaps";
     import { get_beatmap_data } from "../../lib/utils/beatmaps";
     import { input } from "../../lib/store/input";
+    import { show_notification } from "../../lib/store/notifications";
 
     // components
     import Search from "../utils/basic/search.svelte";
@@ -39,8 +40,19 @@
     const update_beatmaps = async () => {
         // hide remove beatmap option if we're showing all beatmaps
         list.hide_remove.set($selected_collection.name == ALL_BEATMAPS_KEY);
-        const beatmaps = await list.get_beatmaps($selected_collection.name, { unique: true, sort: $sort });
-        if (beatmaps) list.set_beatmaps(beatmaps, $selected_collection, true);
+
+        // update list id
+        list.update_list_id($selected_collection.name);
+
+        // get new beatmaps
+        const result = await list.get_beatmaps($selected_collection.name, { unique: true, sort: $sort });
+
+        if (!result) {
+            // show_notification({ type: "error", text: "failed"})
+            return;
+        }
+
+        list.set_beatmaps(result.count, $selected_collection, true);
     };
 
     // update radio bg on beatmap change

--- a/src/renderer/src/lib/store/beatmaps.js
+++ b/src/renderer/src/lib/store/beatmaps.js
@@ -60,6 +60,10 @@ export class BeatmapListBase {
         return get(this.items);
     }
 
+    get_list_length() {
+        return get(this.items).length;
+    }
+
     set_items(items, key, ignore_context = false) {
         this.items.set(items);
 

--- a/src/renderer/src/lib/store/discover.js
+++ b/src/renderer/src/lib/store/discover.js
@@ -189,7 +189,7 @@ class DiscoverManager extends BeatmapListBase {
                 return;
             }
 
-            const data = result.json();
+            const data = await result.json();
 
             // check if we have any beatmaps left to search
             if (!data.beatmapsets || data.beatmapsets.length == 0) {

--- a/src/renderer/src/lib/store/discover.js
+++ b/src/renderer/src/lib/store/discover.js
@@ -145,7 +145,6 @@ class DiscoverManager extends BeatmapListBase {
     search = debounce(async () => {
         // only one at time baby
         if (get(this.is_loading)) {
-            console.log("[discover] already loading, skipping...");
             return;
         }
 
@@ -192,10 +191,9 @@ class DiscoverManager extends BeatmapListBase {
 
             const data = result.json();
 
-            // Verifica se não há mais resultados
+            // check if we have any beatmaps left to search
             if (!data.beatmapsets || data.beatmapsets.length == 0) {
                 this.has_reached_end.set(true);
-                console.log("[discover] no more results available");
                 return;
             }
 
@@ -213,7 +211,7 @@ class DiscoverManager extends BeatmapListBase {
 
             const current_cursor = get(this.cursor);
 
-            // Atualiza a lista de beatmaps
+            // update beatmap list
             if (current_cursor == "") {
                 this.beatmaps.set([...updated_beatmapsets]);
             } else {

--- a/src/renderer/src/lib/store/discover.js
+++ b/src/renderer/src/lib/store/discover.js
@@ -1,7 +1,7 @@
 import { get, writable } from "svelte/store";
 import { access_token } from "./config";
 import { show_notification } from "./notifications";
-import { BeatmapListBase, osu_beatmaps } from "./beatmaps";
+import { BeatmapListBase } from "./beatmaps";
 import { debounce } from "../utils/utils";
 
 // l
@@ -67,6 +67,8 @@ class DiscoverManager extends BeatmapListBase {
         this.last_query = writable("");
         this.data = writable(DEFAULT_DATA_VALUES);
         this.should_update = writable(false);
+        this.is_loading = writable(false);
+        this.has_reached_end = writable(false);
 
         // track last search state to detect changes
         this.last_search_state = "";
@@ -141,6 +143,12 @@ class DiscoverManager extends BeatmapListBase {
     }
 
     search = debounce(async () => {
+        // only one at time baby
+        if (get(this.is_loading)) {
+            console.log("[discover] already loading, skipping...");
+            return;
+        }
+
         const token = get(access_token);
 
         if (token == "") {
@@ -148,20 +156,99 @@ class DiscoverManager extends BeatmapListBase {
             return;
         }
 
+        // dont make more request if we reached the end
+        if (get(this.has_reached_end)) {
+            console.log("[discover] reached end of results");
+            return;
+        }
+
+        this.is_loading.set(true);
+
         const current_state = this.get_current_search_state();
 
         // reset cursor/beatmaps if search parameters changed
         if (this.last_search_state != current_state) {
             this.cursor.set("");
             this.beatmaps.set([]);
+            this.has_reached_end.set(false);
             this.last_search_state = current_state;
         }
 
-        const normalized_data = [];
+        try {
+            const normalized_data = this.normalize_filter_data(get(this.data));
+            const baked_url = this.bake_url(normalized_data);
 
-        for (const [key, values] of Object.entries(get(this.data))) {
-            // for some reason the osu! api use a single char for filter params...
+            const result = await window.fetch({
+                url: baked_url,
+                headers: {
+                    Authorization: "Bearer " + token
+                }
+            });
+
+            if (result.status != 200) {
+                console.log("[discover] failed to fetch beatmaps", result);
+                return;
+            }
+
+            const data = result.json();
+
+            // Verifica se não há mais resultados
+            if (!data.beatmapsets || data.beatmapsets.length == 0) {
+                this.has_reached_end.set(true);
+                console.log("[discover] no more results available");
+                return;
+            }
+
+            // append download, local
+            const updated_beatmapsets = await Promise.all(
+                data.beatmapsets.map(async (set) => {
+                    const local_beatmap = await this.get_from_local_by_id(set.id);
+                    if (local_beatmap) {
+                        set.downloaded = local_beatmap.downloaded;
+                        set.local = local_beatmap.local;
+                    }
+                    return set;
+                })
+            );
+
+            const current_cursor = get(this.cursor);
+
+            // Atualiza a lista de beatmaps
+            if (current_cursor == "") {
+                this.beatmaps.set([...updated_beatmapsets]);
+            } else {
+                this.beatmaps.update((sets) => [...sets, ...updated_beatmapsets]);
+            }
+
+            // update cursor
+            const new_cursor = data.cursor_string || "";
+            this.cursor.set(new_cursor);
+
+            // that means we reached the end ;-;
+            if (new_cursor == "") {
+                this.has_reached_end.set(true);
+            }
+
+            this.last_query.set(get(this.query));
+        } catch (error) {
+            console.error("[discover] search error:", error);
+            show_notification({ type: "error", text: "failed to search beatmaps" });
+        } finally {
+            this.is_loading.set(false);
+        }
+    }, 500);
+
+    normalize_filter_data(data) {
+        const normalized_data = {};
+
+        for (const [key, values] of Object.entries(data)) {
+            // for some reason the osu! api use a single char for filter params..
             const filter_data = filter_map.get(key);
+
+            if (!filter_data) {
+                continue;
+            }
+
             const new_key = filter_data.code;
 
             // return the expected filter value (ex: japanese -> 13)
@@ -172,57 +259,22 @@ class DiscoverManager extends BeatmapListBase {
                 } else {
                     normalized_data[new_key] = filter_data.data[values];
                 }
-            } else {
-                for (const value of values) {
-                    // in this case, the value will be the same
-                    if (Array.isArray(filter_data.data)) {
-                        normalized_data[new_key] = value;
-                    } else {
-                        normalized_data[new_key] = filter_data.data[value];
+            } else if (Array.isArray(values) && values.length > 0) {
+                // in this case, the value will be the same
+                if (Array.isArray(filter_data.data)) {
+                    normalized_data[new_key] = values;
+                } else {
+                    const mapped_values = values.map((value) => filter_data.data[value]).filter((val) => val != undefined);
+
+                    if (mapped_values.length > 0) {
+                        normalized_data[new_key] = mapped_values;
                     }
                 }
             }
         }
 
-        const baked_url = this.bake_url(normalized_data);
-
-        const result = await window.fetch({
-            url: baked_url,
-            headers: {
-                Authorization: "Bearer " + token
-            }
-        });
-
-        if (result.status != 200) {
-            console.log("[discover] failed to fetch beatmaps", result);
-            return;
-        }
-
-        const data = result.json();
-
-        // only append if we are paginating, otherwise replace
-        const current_cursor = get(this.cursor);
-
-        // append download, local (so we know what maps we have)
-        const updated_beatmapsets = data.beatmapsets.map(async (set) => {
-            const local_beatmap = await this.get_from_local_by_id(set.id);
-            if (local_beatmap) {
-                set.downloaded = local_beatmap.downloaded;
-                set.local = local_beatmap.local;
-            }
-            return set;
-        });
-
-        if (current_cursor == "") {
-            this.beatmaps.set([...updated_beatmapsets]);
-        } else {
-            this.beatmaps.update((sets) => [...sets, ...updated_beatmapsets]);
-        }
-
-        this.cursor.set(data.cursor_string || "");
-        this.last_query.set(get(this.query));
-        this.should_update.set(false);
-    }, 250);
+        return normalized_data;
+    }
 
     update(type, value) {
         if (!filter_map.has(type)) {
@@ -254,7 +306,7 @@ class DiscoverManager extends BeatmapListBase {
         // force immediate reset and search trigger
         this.cursor.set("");
         this.beatmaps.set([]);
-        this.should_update.set(true);
+        this.has_reached_end.set(false);
 
         // trigger search immediately after filter change
         this.search();
@@ -278,7 +330,12 @@ class DiscoverManager extends BeatmapListBase {
     update_query(value) {
         if (get(this.query) == value) return;
         this.query.set(value);
+        this.has_reached_end.set(false);
         this.search();
+    }
+
+    can_load_more() {
+        return !get(this.is_loading) && !get(this.has_reached_end);
     }
 }
 

--- a/src/renderer/src/lib/store/downloader.js
+++ b/src/renderer/src/lib/store/downloader.js
@@ -126,9 +126,6 @@ class Downloader {
 
 export const downloader = new Downloader();
 
-// initialize downloader
-await downloader.initialize();
-
 // add listener
 window.downloader.on_downloads_update((data) => downloader.update_downloads(data));
 

--- a/src/renderer/src/lib/utils/collections.js
+++ b/src/renderer/src/lib/utils/collections.js
@@ -17,7 +17,7 @@ export const get_osu_data = async (force) => {
         return;
     }
 
-    const osu_promises = [window.osu.get_collections(force), window.osu.get_beatmaps(force)];
+    const osu_promises = [window.osu.get_collections(force), window.osu.load_beatmaps(force)];
     const osu_result = await Promise.all(osu_promises);
 
     // check if we failed to get osu! data
@@ -28,7 +28,7 @@ export const get_osu_data = async (force) => {
 
     const collection_data = osu_result[0];
 
-    const collections_array = Array.from(collection_data.collections.values());
+    const collections_array = collection_data.collections;
     const version = collection_data.version;
 
     // remove selected colection


### PR DESCRIPTION
- [x] manage lists on main process 
- [ ] fix list filters (query, status, etc...) not working
- [ ] lazy load (render item placeholder then update with actual data)

## Summary by Sourcery

Improve beatmap list performance by sending only count information from the main process, rendering placeholder items in the renderer, and lazy-loading detailed beatmap data on demand with infinite scroll support.

New Features:
- Implement virtualized beatmap lists with placeholders and lazy-loading of individual items
- Introduce infinite scrolling in Discover tab via on_update callbacks

Enhancements:
- Refactor main process to return only list count and metadata instead of full hash arrays
- Add caching and pagination flags (is_loading, has_reached_end) in DiscoverManager
- Update virtual-list component to emit on_update events for load-more triggers
- Simplify BeatmapListBase and BeatmapList to generate placeholder items based on count and support incremental updates
- Migrate IPC handlers and preload bridge to new APIs: load_beatmaps and update_beatmap_list