### PR TITLE
refactor: small changes to beatmap list

### DIFF
--- a/src/renderer/src/assets/app.css
+++ b/src/renderer/src/assets/app.css
@@ -80,10 +80,6 @@ body {
     color: #ffffff;
     height: 100vh;
     overflow: hidden;
-    font-family:
-        system-ui,
-        -apple-system,
-        sans-serif;
 }
 
 #app {

--- a/src/renderer/src/components/beatmaps.svelte
+++ b/src/renderer/src/components/beatmaps.svelte
@@ -28,10 +28,10 @@
     export let set = false;
     export let show_control = true;
     export let remove_callback = () => {};
-    export let on_update = null;
+    export let on_update = () => {};
 
     const list = list_manager || get_beatmap_list(tab_id);
-    const { beatmaps, selected } = list;
+    const { beatmaps, selected, list_id } = list;
 
     $: all_collections = collections.all_collections;
     $: should_hide_remove = list.hide_remove;
@@ -152,6 +152,7 @@
         <div class="results-count">{$beatmaps?.length ?? 0} matches</div>
     </div>
     <VirtualList
+        key={$list_id}
         count={$beatmaps?.length ?? 0}
         width="100%"
         height="100%"

--- a/src/renderer/src/components/tabs/collections.svelte
+++ b/src/renderer/src/components/tabs/collections.svelte
@@ -29,7 +29,7 @@
     const list = get_beatmap_list("collections");
     const popup_manager = get_popup_manager("collections");
 
-    const { sort, query, status, show_invalid } = list;
+    const { sort, query, status, show_invalid, sr_range } = list;
 
     $: filtered_collections = collections.collections;
     $: selected_collection = collections.selected;
@@ -52,6 +52,7 @@
 
         if (result) {
             list.set_beatmaps(result, $query, false);
+            list.update_list_id($selected_collection.name);
         }
     };
 
@@ -628,10 +629,7 @@
         collections.filter();
     }
 
-    // @TODO: this makes us request the collection every time we go into this tab
-    // for small collections this is not a big of a problem since the collections are usually small
-    // but on radio we can notice a small delay since we're doing this 2 times
-    $: if ($selected_collection.name || $query || $sort || $status || $show_invalid) {
+    $: if ($selected_collection.name != undefined && ($query || $sort || $status || $show_invalid || $sr_range)) {
         filter_beatmaps();
     }
 

--- a/src/renderer/src/components/tabs/discover.svelte
+++ b/src/renderer/src/components/tabs/discover.svelte
@@ -62,8 +62,8 @@
             columns={2}
             list_manager={discover}
             on_update={(i) => {
-                // update list on 10 items to the end
-                if (discover.can_load_more() && discover.get_list_length() - i <= 10) {
+                // update list on last index
+                if (discover.can_load_more() && discover.get_list_length() - i <= 2) {
                     discover.search();
                 }
             }}

--- a/src/renderer/src/components/tabs/radio.svelte
+++ b/src/renderer/src/components/tabs/radio.svelte
@@ -39,8 +39,13 @@
     const update_beatmaps = async () => {
         // hide remove beatmap option if we're showing all beatmaps
         list.hide_remove.set($selected_collection.name == ALL_BEATMAPS_KEY);
+        
         const beatmaps = await list.get_beatmaps($selected_collection.name, { unique: true, sort: $sort });
-        if (beatmaps) list.set_beatmaps(beatmaps, $selected_collection, true);
+
+        if (beatmaps) { 
+            list.set_beatmaps(beatmaps, $selected_collection, true);
+            list.update_list_id($selected_collection.name);
+        }
     };
 
     // update radio bg on beatmap change

--- a/src/renderer/src/lib/store/beatmaps.js
+++ b/src/renderer/src/lib/store/beatmaps.js
@@ -43,7 +43,7 @@ const managers = new Map();
 
 export class BeatmapListBase {
     constructor(list_id) {
-        this.list_id = list_id;
+        this.list_id = writable(list_id);
         this.last_options = null;
         this.last_result = null; // last beatmap array or something
         this.hide_remove = writable(false); // hide remove beatmap option from context menu
@@ -110,6 +110,14 @@ export class BeatmapListBase {
         return this.is_same_item(item, current);
     }
 
+    update_list_id(id) {
+        this.list_id.set(id);
+    }
+
+    update_query(value) {
+        this.query.set(value);
+    }
+
     clear() {
         // clear stores
         this.items.set([]);
@@ -119,10 +127,6 @@ export class BeatmapListBase {
         // clear normal values
         this.last_options = null;
         this.last_result = null;
-    }
-
-    update_query(value) {
-        this.query.set(value);
     }
 }
 


### PR DESCRIPTION
- [x] removed debounce from on_update (so we get update for each item)
- [x] use list_id on beatmaps to update virtual list
- [x] other misc changes

## Summary by Sourcery

Refactor virtual list to emit updates for every rendered item, streamline its lifecycle, and leverage a reactive list_id key for view synchronization; extend BeatmapListBase with writable stores and updater methods; propagate list_id on collection and radio tabs to refresh lists; tune infinite-scroll threshold in discover; remove default global font-family.

Enhancements:
- Remove debounce in VirtualList and invoke on_update for each item render
- Auto-scroll selected item and reset element cache on key changes in VirtualList
- Simplify VirtualList lifecycle cleanup and inline unique IDs instead of get_key
- Convert BeatmapListBase.list_id to a writable store and add update_list_id/update_query methods
- Pass reactive list_id as key to VirtualList and update it in collections and radio tabs
- Adjust discover tab to trigger loading two items from the end instead of ten
- Remove global default font-family from application CSS