### PR TITLE
feat: yt_dlp wrapper, song downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/*
 .vscode/
 *.lock
 bin
+.temp

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "format": "prettier --plugin prettier-plugin-svelte --write .",
         "start": "bun run rebuild && electron-vite preview",
         "dev": "bun run rebuild && electron-vite dev",
-        "test": "node-gyp clean && node-gyp configure && node-gyp-build",
+        "test": "bun test",
         "build": "electron-vite build",
         "rebuild": "bun x electron-rebuild",
         "postinstall": "electron-builder install-app-deps",
@@ -20,9 +20,9 @@
     "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
+        "adm-zip": "^0.5.16",
         "better-sqlite3": "^12.2.0",
         "jszip": "^3.10.1",
-        "node-stream-zip": "^1.15.0",
         "realm": "20.2.0",
         "wx-svelte-menu": "^2.2.1"
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "@electron-toolkit/utils": "^4.0.0",
         "better-sqlite3": "^12.2.0",
         "jszip": "^3.10.1",
+        "node-stream-zip": "^1.15.0",
         "realm": "20.2.0",
         "wx-svelte-menu": "^2.2.1"
     },

--- a/src/main/beatmaps/builder.js
+++ b/src/main/beatmaps/builder.js
@@ -156,12 +156,11 @@ class BeatmapBuilder {
         // add .osu file
         zip.file(`${file_name}.osu`, buffer);
 
-        const zipped = await zip.generateAsync({
-            type: "nodebuffer",
-            compression: "DEFLATE"
-        });
+        return await zip.generateAsync({
+                    type: "nodebuffer",
+                    compression: "DEFLATE"
+                });
 
-        return zipped;
     }
 }
 

--- a/src/main/beatmaps/builder.js
+++ b/src/main/beatmaps/builder.js
@@ -1,0 +1,163 @@
+import JSZip from "jszip";
+import fs from "fs";
+import path from "path";
+
+const DEFAULT_AUDIO_NAME = "audio.mp3";
+
+// @TODO: background / storyboard support
+class LegacyBeatmapFile {
+    constructor() {
+        this.properties = new Map();
+        this.version = "osu file format v14\n";
+        this.section_data = new Map([
+            // @TODO: idk if this is broken, tested with a .opus file and dint work (maybe .opus issue? idk)
+            [
+                "General",
+                [
+                    { key: "AudioFilename", required: true },
+                    { key: "SampleSet", value: "None" },
+                    { key: "AudioLeadIn", value: 0 },
+                    { key: "PreviewTime", value: -1 },
+                    { key: "Countdown", value: 0 },
+                    { key: "StackLeniency", value: 0.7 },
+                    { key: "Mode", value: 0 },
+                    { key: "LetterboxInBreaks", value: 0 },
+                    { key: "WidescreenStoryboard", value: 0 }
+                ]
+            ],
+            [
+                "Editor",
+                [
+                    { key: "DistanceSpacing", value: 2 },
+                    { key: "BeatDivisor", value: 4 },
+                    { key: "GridSize", value: 1 },
+                    { key: "TimelineZoom", value: 1 }
+                ]
+            ],
+            [
+                "Metadata",
+                [
+                    { key: "Title", required: true },
+                    { key: "TitleUnicode", value: "" },
+                    { key: "Artist", required: true },
+                    { key: "ArtistUnicode", value: "" },
+                    { key: "Creator", value: "osu-stuff" },
+                    { key: "Version", value: "hello, world!" },
+                    { key: "Source", value: "" },
+                    { key: "Tags", value: "" },
+                    { key: "BeatmapID", value: 0 },
+                    { key: "BeatmapSetID", value: -1 }
+                ]
+            ],
+            [
+                "Difficulty",
+                [
+                    { key: "HPDrainRate", value: 5 },
+                    { key: "CircleSize", value: 5 },
+                    { key: "OverallDifficulty", value: 5 },
+                    { key: "ApproachRate", value: 5 },
+                    { key: "SliderMultiplier", value: 1.4 },
+                    { key: "SliderTickRate", value: 1 }
+                ]
+            ],
+            ["Events", []],
+            ["HitObject", []]
+        ]);
+    }
+
+    set(key, value) {
+        this.properties.set(key, value);
+    }
+
+    get(key) {
+        return this.properties.get(key);
+    }
+
+    has(key) {
+        return this.properties.has(key);
+    }
+}
+
+class BeatmapBuilder {
+    constructor() {}
+
+    create() {
+        return new LegacyBeatmapFile();
+    }
+
+    read() {
+        throw new Error("read(): not implemented yet");
+    }
+
+    /** @param {LegacyBeatmapFile} file */
+    write(file) {
+        if ((!file) instanceof LegacyBeatmapFile) {
+            throw new Error("NOOOOOOOOOO");
+        }
+
+        // initialize buffer with version
+        const buffer = [file.version];
+
+        for (const [section, data] of file.section_data) {
+            // write new section
+            buffer.push(`[${section}]`);
+
+            // add section properties
+            for (const property of data) {
+                let value = "";
+                const has_custom_value = file.has(property.key);
+
+                // throws if we dont have a required key
+                if (property.required && !has_custom_value) {
+                    throw new Error(`builder: missing ${property.key}`);
+                }
+
+                // mhm
+                if ((property.key == "ArtistUnicode" || property.key == "TitleUnicode") && !has_custom_value) {
+                    value = file.get(property.key.split("U")[0]) ?? "";
+                }
+
+                // fallback to default value if available
+                if (!value) {
+                    value = has_custom_value ? file.get(property.key) : property.value;
+                }
+
+                buffer.push(`${property.key}:${value}`);
+            }
+
+            buffer.push(""); // add blank line between each section
+        }
+
+        return buffer.join("\n");
+    }
+
+    /** @param {LegacyBeatmapFile} file */
+    async zip(file) {
+        const buffer = this.write(file);
+        const zip = new JSZip();
+
+        const file_location = file.get("AudioLocation");
+        const file_name = file.get("Title");
+
+        // ensure audio file exists
+        if (!fs.existsSync(file_location)) {
+            console.log("builder: failed to find audio file");
+            return false;
+        }
+
+        // add audio file
+        zip.file(DEFAULT_AUDIO_NAME, fs.readFileSync(file_location));
+
+        // add .osu file
+        zip.file(`${file_name}.osu`, buffer);
+
+        const zipped = await zip.generateAsync({
+            type: "nodebuffer",
+            compression: "DEFLATE"
+        });
+
+        return zipped;
+    }
+}
+
+export const beatmap_builder = new BeatmapBuilder();

--- a/src/main/beatmaps/builder.js
+++ b/src/main/beatmaps/builder.js
@@ -115,8 +115,8 @@ class BeatmapBuilder {
                 // Use explicit mapping for Unicode keys to their fallback values
                 if (!has_custom_value && (property.key === "ArtistUnicode" || property.key === "TitleUnicode")) {
                     const fallbackMap = {
-                        "ArtistUnicode": "Artist",
-                        "TitleUnicode": "Title"
+                        ArtistUnicode: "Artist",
+                        TitleUnicode: "Title"
                     };
                     const fallbackKey = fallbackMap[property.key];
                     value = file.get(fallbackKey) ?? "";
@@ -157,10 +157,9 @@ class BeatmapBuilder {
         zip.file(`${file_name}.osu`, buffer);
 
         return await zip.generateAsync({
-                    type: "nodebuffer",
-                    compression: "DEFLATE"
-                });
-
+            type: "nodebuffer",
+            compression: "DEFLATE"
+        });
     }
 }
 

--- a/src/main/beatmaps/builder.js
+++ b/src/main/beatmaps/builder.js
@@ -112,9 +112,14 @@ class BeatmapBuilder {
                     throw new Error(`builder: missing ${property.key}`);
                 }
 
-                // mhm
-                if ((property.key == "ArtistUnicode" || property.key == "TitleUnicode") && !has_custom_value) {
-                    value = file.get(property.key.split("U")[0]) ?? "";
+                // Use explicit mapping for Unicode keys to their fallback values
+                if (!has_custom_value && (property.key === "ArtistUnicode" || property.key === "TitleUnicode")) {
+                    const fallbackMap = {
+                        "ArtistUnicode": "Artist",
+                        "TitleUnicode": "Title"
+                    };
+                    const fallbackKey = fallbackMap[property.key];
+                    value = file.get(fallbackKey) ?? "";
                 }
 
                 // fallback to default value if available

--- a/src/main/beatmaps/builder.js
+++ b/src/main/beatmaps/builder.js
@@ -91,8 +91,8 @@ class BeatmapBuilder {
 
     /** @param {LegacyBeatmapFile} file */
     write(file) {
-        if ((!file) instanceof LegacyBeatmapFile) {
-            throw new Error("NOOOOOOOOOO");
+        if (!(file instanceof LegacyBeatmapFile)) {
+            throw new Error("builder: not a instance of LegacyBeatmapFile...");
         }
 
         // initialize buffer with version

--- a/src/main/dlp/dlp.js
+++ b/src/main/dlp/dlp.js
@@ -1,0 +1,188 @@
+import path from "path";
+import fs from "fs";
+
+import { spawn } from "child_process";
+import { get_app_path } from "../database/utils";
+
+class SongDownloader {
+    constructor(repository, location) {
+        if (!location || !repository) {
+            throw new Error("missing paramater");
+        }
+
+        this.temp_location = path.resolve(location, "temp");
+        this.downloaded_location = path.resolve(location, "downloaded");
+
+        if (!fs.existsSync(location)) {
+            fs.mkdirSync(location, { recursive: true });
+        }
+
+        if (!fs.existsSync(this.temp_location)) {
+            fs.mkdirSync(this.temp_location);
+        }
+
+        if (!fs.existsSync(this.downloaded_location)) {
+            fs.mkdirSync(this.downloaded_location);
+        }
+
+        this.repository = repository;
+        this.ext = process.platform == "win32" ? "_x86.exe" : "_linux";
+        this.binary_location = path.resolve(location, `yt-dlp${this.ext}`);
+        this.version_location = path.resolve(location, "yt-dlp-version");
+        this.version = "";
+    }
+
+    async initialize() {
+        // check if our binary already exists
+        if (fs.existsSync(this.binary_location) && fs.existsSync(this.version_location)) {
+            const saved_version = fs.readFileSync(this.version_location, "utf-8");
+            const latest_version = await this.get_latest_version();
+
+            // check if we're on the latest version
+            if (saved_version == latest_version) {
+                this.update_version(latest_version);
+                return;
+            }
+
+            console.log(`dlp: detected new yt-dlp version\ndownloading: ${latest_version}`);
+        } else {
+            console.log("dlp: downloading latest yt-dlp binary");
+        }
+
+        // otherwise download latest version
+        const new_binary = await this.download_latest_binary();
+
+        if (!new_binary) {
+            console.error("dlp: failed to download yt-dlp binary");
+            return;
+        }
+
+        const { buffer, version } = new_binary;
+
+        // update binary / version
+        fs.writeFileSync(this.binary_location, Buffer.from(buffer));
+
+        // give exec permission on linux
+        if (process.platform == "linux") {
+            console.log("dlp: ensuring yt-dlp binary has exec permissions");
+            fs.chmodSync(this.binary_location, 0o755);
+        }
+
+        this.update_version(version);
+        console.log(`dlp: downloaded ${version} succesfully`);
+    }
+
+    async get_latest_version() {
+        const result = await fetch(`https://api.github.com/repos/${this.repository}/releases/latest`);
+
+        if (result.status != 200) {
+            console.log("dlp: failed to get latest version, reason:", result.statusText);
+            return false;
+        }
+
+        const data = await result.json();
+        return data.name;
+    }
+
+    async download_latest_binary() {
+        const result = await fetch(`https://api.github.com/repos/${this.repository}/releases/latest`);
+
+        if (result.status != 200) {
+            console.log("dlp: failed to fetch github, reason:", result.statusText);
+            return false;
+        }
+
+        const data = await result.json();
+
+        // loop through assets until we find the correct binary
+        const target_name = process.platform == "win32" ? "yt-dlp_x86.exe" : "yt-dlp_linux";
+        const target_asset = data.assets.find((a) => a.name == target_name);
+
+        if (!target_asset) {
+            console.log("dlp: unable to find target name:", target_name);
+            return false;
+        }
+
+        const download_result = await fetch(target_asset.browser_download_url);
+
+        if (download_result.status != 200) {
+            console.log("dlp: failed to download yt-dlp binary, reason:", download_result.statusText);
+            return false;
+        }
+
+        const buffer = await download_result.arrayBuffer();
+        return { version: data.name, buffer };
+    }
+
+    update_version(version) {
+        this.version = version;
+        fs.writeFileSync(this.version_location, version, "utf-8");
+    }
+
+    async download(url) {
+        // check if the binary exists
+        if (!url || !fs.existsSync(this.binary_location)) {
+            return false;
+        }
+
+        // build args
+        const args = [
+            "-x",
+            "--audio-format",
+            "opus",
+            "-N",
+            "6",
+            "--http-chunk-size",
+            "10M",
+            "--paths",
+            `temp:${this.temp_location}`,
+            "--paths",
+            `home:${this.downloaded_location}`,
+            url
+        ];
+
+        const result = await new Promise((r) => {
+            const proc = spawn(this.binary_location, args);
+            let stdout_buffer = "";
+
+            proc.stdout.on("data", (d) => {
+                stdout_buffer += d.toString();
+            });
+
+            proc.stderr.on("data", () => {});
+
+            proc.on("close", (code) => {
+                if (code == 0) {
+                    // get file location
+                    const lines = stdout_buffer
+                        .split("\n")
+                        .map((l) => l.trim())
+                        .filter((l) => l);
+                    const move_line = lines.find((l) => l.includes("[MoveFiles]"));
+
+                    if (!move_line) {
+                        r(null);
+                        return;
+                    }
+
+                    // return null if we didn't find anything
+                    const audio_location = move_line.split(" to ")[1]?.replace(/^["']|["']$/g, "");
+
+                    if (!audio_location) {
+                        r(null);
+                        return;
+                    }
+
+                    const audio_name = path.basename(audio_location);
+                    r({ name: audio_name, location: audio_location });
+                }
+
+                r(null);
+            });
+        });
+
+        return result;
+    }
+}
+
+export const song_downloader = new SongDownloader("yt-dlp/yt-dlp", get_app_path());

--- a/src/main/dlp/song.js
+++ b/src/main/dlp/song.js
@@ -70,8 +70,10 @@ export class SongDownloader {
             return false;
         }
 
-        // return null if we didn't find anything
-        const audio_location = move_line.split(" to ")[1]?.replace(/^["']|["']$/g, "");
+        // Use a regular expression to robustly extract the file path from the [MoveFiles] line
+        const moveFilesRegex = /\[MoveFiles\].* to (["']?)(.+?)\1$/;
+        const match = move_line.match(moveFilesRegex);
+        const audio_location = match ? match[2] : null;
 
         if (!audio_location) {
             return false;

--- a/src/main/dlp/song.js
+++ b/src/main/dlp/song.js
@@ -1,0 +1,78 @@
+import path from "path";
+import fs from "fs";
+
+import { yt_dlp } from "./dlp";
+import { get_app_path } from "../database/utils";
+
+// @TODO: send notification to main process on success, error, etc...
+
+class SongDownloader  {
+    constructor(repository, location) {
+        if (!location || !repository) {
+            throw new Error("missing paramater");
+        }
+
+        this.downloaded_location = path.resolve(location, "downloaded");
+        this.temp_location = path.resolve(location, "temp");
+
+        if (!fs.existsSync(this.downloaded_location)) {
+            fs.mkdirSync(this.downloaded_location, { recursive: true });
+        }
+    }
+
+    async initialize() {
+        await yt_dlp.initialize();
+    }
+
+    async download(url) {
+        // check if url is provided
+        if (!url) {
+            return false;
+        }
+
+        // build args
+        const download_args = [
+            "-x",
+            "--audio-format",
+            "mp3",
+            "-N",
+            "6",
+            "--http-chunk-size",
+            "10M",
+            "--paths",
+            `temp:${this.temp_location}`,
+            "--paths",
+            `home:${this.downloaded_location}`,
+            url
+        ];
+
+        const result = await yt_dlp.exec(download_args);
+
+        if (!result || result.code !== 0) {
+            return null;
+        }
+
+        // get file location from stdout
+        const lines = result.stdout
+            .split("\n")
+            .map((l) => l.trim())
+            .filter((l) => l);
+        const move_line = lines.find((l) => l.includes("[MoveFiles]"));
+
+        if (!move_line) {
+            return null;
+        }
+
+        // return null if we didn't find anything
+        const audio_location = move_line.split(" to ")[1]?.replace(/^["']|["']$/g, "");
+
+        if (!audio_location) {
+            return null;
+        }
+
+        const audio_name = path.basename(audio_location);
+        return { name: audio_name, location: audio_location };
+    }
+}
+
+export const song_downloader = new SongDownloader("yt-dlp/yt-dlp", get_app_path());

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+import { $ } from "bun";
+
+export const TEST_TARGET_PATH = path.resolve(__dirname, ".temp");
+
+export const create_temp_path = () => {
+    if (!fs.existsSync(TEST_TARGET_PATH)) {
+        fs.mkdirSync(TEST_TARGET_PATH);
+    }
+};
+
+export const clean_test_path = async () => {
+    if (!fs.existsSync(TEST_TARGET_PATH)) {
+        create_temp_path();
+    }
+
+    let result = "";
+
+    if (process.platform == "win32") {
+        result = await $`powershell -Command "Remove-Item '${TEST_TARGET_PATH}\\*' -Force -Recurse -ErrorAction SilentlyContinue"`.text();
+    } else {
+        result = await $`rm ${TEST_TARGET_PATH}/*`.text();
+    }
+
+    console.log("clean_test_path():", result);
+};

--- a/tests/yt_dlp.test.js
+++ b/tests/yt_dlp.test.js
@@ -1,0 +1,123 @@
+import fs from "fs";
+import path from "path";
+
+import { describe, expect, test } from "bun:test";
+import { TEST_TARGET_PATH, clean_test_path } from "./utils";
+import { YTdlp } from "../src/main/dlp/dlp";
+import { SongDownloader } from "../src/main/dlp/song";
+
+const TARGET_YT_SONG = "https://www.youtube.com/watch?v=KJotmmDJWAg";
+
+// create new yt_dlp instance
+const new_instance = new YTdlp(TEST_TARGET_PATH);
+
+describe("yt-dlp", async () => {
+    // ensure we initialize with a empty test path
+    await clean_test_path();
+
+    test(
+        "initialize new yt-dlp instance",
+        async () => {
+            const result = await new_instance.initialize();
+            expect(result).toBe(true);
+        },
+        { timeout: 20000 }
+    );
+
+    test("check downloaded binaries", () => {
+        const target_binary = new_instance.name;
+        const file_exists = fs.existsSync(path.resolve(TEST_TARGET_PATH, target_binary));
+
+        expect(file_exists).toBe(true);
+
+        // only test ffmpeg on windows
+        if (process.platform == "win32") {
+            let target_binaries = ["ffmpeg.exe", "ffplay.exe", "ffprobe.exe"];
+
+            const ffmpeg_folder_exists = fs.existsSync(path.resolve(TEST_TARGET_PATH, "ffmpeg"));
+            expect(ffmpeg_folder_exists).toBe(true);
+
+            if (ffmpeg_folder_exists) {
+                const ffmpeg_binaries = fs.readdirSync(path.resolve(TEST_TARGET_PATH, "ffmpeg"));
+
+                // vheck if all required binaries exist
+                const all_binaries_exist = target_binaries.every((target) => ffmpeg_binaries.some((b) => b.includes(target.replace(".exe", ""))));
+
+                expect(all_binaries_exist).toBe(true);
+            }
+        }
+    });
+
+    // test if binary is executable and returns version info
+    test(
+        "yt-dlp binary is functional",
+        async () => {
+            const result = await new_instance.exec(["--version"]);
+            console.log(result);
+            expect(result).toBeObject();
+            expect(result.code).toBe(0);
+        },
+        { timeout: 10000 }
+    );
+});
+
+describe("song downloader", () => {
+    // create new instance
+    const song_downloader = new SongDownloader(TEST_TARGET_PATH, new_instance);
+
+    test(
+        "initialize new song download instance",
+        async () => {
+            await song_downloader.initialize();
+
+            // test that the downloader was properly initialized
+            expect(song_downloader.dlp.is_binary_available()).toBe(true);
+            expect(fs.existsSync(song_downloader.downloaded_location)).toBe(true);
+        },
+        { timeout: 1000 }
+    );
+
+    test(
+        "download random youtube song",
+        async () => {
+            const result = await song_downloader.download(TARGET_YT_SONG);
+
+            // check if result is not false/null
+            expect(result).not.toBe(false);
+            expect(result).not.toBe(null);
+            expect(result).toBeObject();
+
+            // check if result has expected properties
+            expect(result).toHaveProperty("name");
+            expect(result).toHaveProperty("location");
+            expect(typeof result.name).toBe("string");
+            expect(typeof result.location).toBe("string");
+
+            // check if downloaded file exists
+            expect(fs.existsSync(result.location)).toBe(true);
+
+            // check if file has some content
+            const stats = fs.statSync(result.location);
+            expect(stats.size).toBeGreaterThan(0);
+        },
+        { timeout: 30000 }
+    );
+
+    test(
+        "download with invalid URL",
+        async () => {
+            const result = await song_downloader.download("invalid url");
+            expect(result).toBe(false);
+        },
+        { timeout: 10000 }
+    );
+
+    test(
+        "download without URL",
+        async () => {
+            const result = await song_downloader.download();
+            expect(result).toBe(false);
+        },
+        { timeout: 1000 }
+    );
+});


### PR DESCRIPTION
- [x] yt-dlp wrapper (win/linux)
- [x] download ffmpeg binary on windows (required by yt-dlp)
- [x] beatmap creator (create beatmaps with title, artist, song)
- [x] tests

## Summary by Sourcery

Add a SongDownloader module that wraps yt-dlp for fetching, updating, and executing the binary to download audio from URLs and manage file storage.

New Features:
- Introduce SongDownloader class to handle yt-dlp binary installation, version checking, and updates.
- Implement audio download method that extracts opus files from given URLs and stores them in temp and downloaded directories.

## Summary by Sourcery

Add a yt-dlp wrapper with automated binary and ffmpeg handling, a SongDownloader for audio extraction, and a beatmap builder for packaging .osu files with audio; update dependencies and include comprehensive bun:test test coverage

New Features:
- Wrap yt-dlp binary installation, version management, and execution in a YTdlp class
- Implement SongDownloader class to extract MP3 audio from URLs and manage temp/download folders
- Introduce BeatmapBuilder and LegacyBeatmapFile classes to generate .osu files and zip them with audio

Build:
- Update package.json to use bun test for testing and add adm-zip dependency

Tests:
- Add bun:test suites for YTdlp initialization, binary execution, and SongDownloader download scenarios