### PR TITLE
refactor: use adm-zip to build beatmap files instead of jszip

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "@electron-toolkit/utils": "^4.0.0",
         "adm-zip": "^0.5.16",
         "better-sqlite3": "^12.2.0",
-        "jszip": "^3.10.1",
         "realm": "20.2.0",
         "wx-svelte-menu": "^2.2.1"
     },

--- a/src/main/beatmaps/builder.js
+++ b/src/main/beatmaps/builder.js
@@ -1,4 +1,4 @@
-import JSZip from "jszip";
+import AdmZip from "adm-zip";
 import fs from "fs";
 import path from "path";
 
@@ -137,9 +137,9 @@ class BeatmapBuilder {
     }
 
     /** @param {LegacyBeatmapFile} file */
-    async zip(file) {
+    zip(file) {
         const buffer = this.write(file);
-        const zip = new JSZip();
+        const zip = new AdmZip();
 
         const file_location = file.get("AudioLocation");
         const file_name = file.get("Title");
@@ -151,15 +151,12 @@ class BeatmapBuilder {
         }
 
         // add audio file
-        zip.file(DEFAULT_AUDIO_NAME, fs.readFileSync(file_location));
+        zip.addLocalFile(DEFAULT_AUDIO_NAME, file_location);
 
         // add .osu file
-        zip.file(`${file_name}.osu`, buffer);
+        zip.addFile(`${file_name}.osu`, buffer);
 
-        return await zip.generateAsync({
-            type: "nodebuffer",
-            compression: "DEFLATE"
-        });
+        return zip.toBuffer();
     }
 }
 


### PR DESCRIPTION
benefits:
- its faster
- it just works

## Summary by Sourcery

Use adm-zip instead of jszip for building beatmap archives, reorganize file gathering into clear helper functions, and update the export and builder modules for improved performance and reliability

Enhancements:
- Replace jszip with adm-zip to speed up and simplify beatmap ZIP creation
- Refactor beatmap export logic to collect file lists before zipping and handle errors centrally
- Modularize file collection into get_beatmap_files, get_stable_beatmap_files, get_lazer_beatmap_files, and get_dir_files functions
- Update BeatmapBuilder.zip to use AdmZip API and return a buffer directly

Build:
- Remove jszip dependency from package.json and add adm-zip