### PR TITLE
fix(radio): check selected beatmap from store instead of the local one (on mount)

### DIFF
--- a/src/renderer/src/components/tabs/radio.svelte
+++ b/src/renderer/src/components/tabs/radio.svelte
@@ -70,7 +70,6 @@
     // update selected map when hash changes
     $: if ($selected) {
         get_beatmap_data($selected).then((bm) => {
-            console.log(bm);
             selected_beatmap = bm;
             update_background_image();
         });


### PR DESCRIPTION
## Summary by Sourcery

Use the global selected beatmap store on component mount to reset audio state correctly, and log fetched beatmap data for debugging.

Bug Fixes:
- Clear audio only when no beatmap is selected in the store instead of relying on the local beatmap variable

Chores:
- Add console.log in get_beatmap_data callback to output fetched beatmap data