### PR TITLE
fix(export collection): on invalid path, create instead of giving an error

### DIFF
--- a/src/main/beatmaps/collections.js
+++ b/src/main/beatmaps/collections.js
@@ -117,7 +117,12 @@ export const export_collection = async (collections, type) => {
 
     // create export if doesn't already exist
     if (!fs.existsSync(config.export_path)) {
-        fs.mkdirSync(config.export_path, { recursive: true });
+        try {
+            fs.mkdirSync(config.export_path, { recursive: true });
+        } catch (err) {
+            result.reason = "failed to create export path: " + err.message;
+            return result;
+        }
     }
 
     const final_name = data.collections.map((c) => c.name).join("-") + `.${type}`;

--- a/src/renderer/src/lib/utils/beatmaps.js
+++ b/src/renderer/src/lib/utils/beatmaps.js
@@ -46,7 +46,7 @@ export const get_by_unique_id = async (id) => {
 export const get_missing_beatmaps = async () => {
     const invalid_beatmaps = [];
 
-    try { 
+    try {
         for (const collection of get(collections.all_collections)) {
             // search for missing beatmaps on the current collection
             const invalid = await window.osu.missing_beatmaps(collection.maps);
@@ -58,8 +58,8 @@ export const get_missing_beatmaps = async () => {
 
         // update missing data
         collections.missing_beatmaps.set(invalid_beatmaps);
-    } catch(err) {
-        show_notification({ type: "error", text: "failed to get missing beatmaps..."});
+    } catch (err) {
+        show_notification({ type: "error", text: "failed to get missing beatmaps..." });
         console.error(err);
     }
 };


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Create the export path directory recursively when missing instead of erroring out