### PR TITLE
fix(sr-filter): handle invalid beatmaps

### DIFF
--- a/src/main/beatmaps/beatmaps.js
+++ b/src/main/beatmaps/beatmaps.js
@@ -147,7 +147,12 @@ export const search_filter = (beatmap, query, search_filters) => {
             // check anyways
             if (!star_rating) break;
 
-            if (!validate_filter(star_rating[gamemode].nm, filter.o, thing)) {
+            // also shouldn't happen...
+            const nomod_star_rating = star_rating[gamemode];
+
+            if (!nomod_star_rating) break;
+
+            if (!validate_filter(nomod_star_rating.nm, filter.o, thing)) {
                 valid = false;
                 break;
             }


### PR DESCRIPTION
## Summary by Sourcery

Add validation and safeguards in search_filter to skip invalid beatmaps without star_rating and correctly index ratings by game mode

Bug Fixes:
- Handle missing star_rating entries to prevent errors during filtering

Enhancements:
- Extract beatmap.mode into a local variable for proper star_rating indexing

Chores:
- Update hack comment to mark remaining improvements with @TOFIX