### PR TITLE
fix(text component): use escape to leave edit move instead of mouse1

### DIFF
--- a/src/renderer/src/components/utils/basic/text.svelte
+++ b/src/renderer/src/components/utils/basic/text.svelte
@@ -19,7 +19,7 @@
 
     // automatically focus on edit
     $: if (element && edit) {
-        input.on("mouse1", () => release(true));
+        input.on("escape", () => release(true));
         input.on("enter", () => release(false));
         element.focus();
     }
@@ -41,7 +41,7 @@
     });
 
     onDestroy(() => {
-        input.unregister("mouse1", "enter");
+        input.unregister("enter", "escape");
     });
 </script>
 


### PR DESCRIPTION
## Summary by Sourcery

Replace mouse click trigger with escape key to exit edit mode in the text component

Bug Fixes:
- Use 'escape' event to exit text edit mode instead of 'mouse1'
- Update input event unregistration to remove 'escape' instead of 'mouse1'